### PR TITLE
On Windows: handle whitespace and '\' in arguments

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,1 @@
+* Test whitespace arguments on Unix

--- a/lib/childprocess/windows/process.rb
+++ b/lib/childprocess/windows/process.rb
@@ -52,8 +52,7 @@ module ChildProcess
           opts[:stderr] = @io.stderr
         end
 
-        # TODO: escape/quote arguments properly
-        command = @args.join ' '
+        command = get_cmdline_str(@args)
 
         @pid = Lib.create_proc(command, opts)
         @handle = Handle.open(@pid)
@@ -63,6 +62,31 @@ module ChildProcess
         end
 
         self
+      end
+
+      # Get a commandline string from an array
+      def get_cmdline_str(args)
+          # Build commandline string, with quotes around arguments with special
+          # characters in them (i.e., characters interpreted by shell)
+          args_str = ""
+          quote = '"'
+          args.each do |arg|
+              if not arg.kind_of?(String)
+                  raise RuntimeError, "Argument not string: '#{arg}' (#{arg.class})"
+              end
+
+              if arg.nil?
+                  next
+              end
+              # Quote whitespace and '\'
+              if not /[\s\\]/.match(arg).nil?
+                  arg = "#{quote}#{arg}#{quote}"
+              end
+              args_str += "#{arg} "
+          end
+          args_str.strip!()
+
+          return args_str
       end
 
     end # Process

--- a/spec/childprocess_spec.rb
+++ b/spec/childprocess_spec.rb
@@ -136,4 +136,16 @@ describe ChildProcess do
     lambda { TCPServer.new("localhost", 4433).close }.should_not raise_error
   end
 
+  it "can handle whitespace and special characters in arguments" do
+    args = ["foo bar", 'foo\bar']
+
+    Tempfile.open("argv-spec") do |file|
+      process = write_argv(file.path, *args).start
+      process.poll_for_exit(EXIT_TIMEOUT)
+
+      file.rewind
+      file.read.should == args.inspect
+    end
+  end
+
 end


### PR DESCRIPTION
Hi Jari!

If you could please incorporate this simple change making ChildProcess on Windows protect whitespace and backslash ('\') in arguments, I'd be much obliged. I have included an rspec test to verify that my changes are good.
