### PR TITLE
Add Process#wait to block and wait for a process

### DIFF
--- a/lib/childprocess/abstract_process.rb
+++ b/lib/childprocess/abstract_process.rb
@@ -72,6 +72,16 @@ module ChildProcess
     end
 
     #
+    # Block until the process has been terminated.
+    #
+    # @return [FixNum] The exit status of the process
+    #
+
+    def wait
+      raise SubclassResponsibility, "wait"
+    end
+
+    #
     # Did the process exit?
     #
     # @return [Boolean]

--- a/lib/childprocess/jruby/process.rb
+++ b/lib/childprocess/jruby/process.rb
@@ -38,6 +38,19 @@ module ChildProcess
       end
 
       #
+      # Block until the process has been terminated.
+      #
+      # @return [FixNum] The exit status of the process
+      #
+
+      def wait
+        @process.waitFor
+
+        stop_pumps
+        @exit_code = @process.exitValue
+      end
+
+      #
       # Only supported in JRuby on a Unix operating system, thanks to limitations
       # in Java's classes
       #

--- a/lib/childprocess/unix/process.rb
+++ b/lib/childprocess/unix/process.rb
@@ -49,11 +49,19 @@ module ChildProcess
         !!pid
       end
 
-      private
+      #
+      # Block until the process has been terminated.
+      #
+      # @return [FixNum] The exit status of the process
+      #
 
       def wait
-        @exit_code = ::Process.waitpid @pid
+        pid, status = ::Process.waitpid2 @pid
+
+        @exit_code = status.exitstatus || status.termsig
       end
+
+      private
 
       def send_term
         send_signal 'TERM'

--- a/lib/childprocess/windows/process.rb
+++ b/lib/childprocess/windows/process.rb
@@ -22,6 +22,16 @@ module ChildProcess
         @handle.close
       end
 
+      #
+      # Block until the process has been terminated.
+      #
+      # @return [FixNum] The exit status of the process
+      #
+
+      def wait
+        @handle.wait
+      end
+
       def exited?
         return true if @exit_code
         assert_started

--- a/spec/childprocess_spec.rb
+++ b/spec/childprocess_spec.rb
@@ -31,6 +31,14 @@ describe ChildProcess do
     process.should_not be_crashed
   end
 
+  it "can wait for a process to finish" do
+    process = exit_with(0).start
+    return_value = process.wait
+
+    process.should_not be_alive
+    return_value.should == 0
+  end
+
   it "escalates if TERM is ignored" do
     process = ignored('TERM').start
     process.stop


### PR DESCRIPTION
I was investigating a performance issue in the cucumber/aruba gem. Profiling turned out that most of the slowdown was caused by launching child processes and waiting for them to finish (with the poll_for_exit method). In my particular case the situation got out of hand because the polling interval was 0.1 seconds while the program that had to be run only took between five and ten milliseconds to execute.

I realized that most of the applications using poll_for_exit could benefit from having direct access to something like waitpid or an equivalent method, so I added the Process#wait method that blocks the current process until the child process is terminated.

The wait method has support for Unix, JRuby and Windows. It has been tested under MRI 1.8.7, 1.9.3 and JRuby 1.6.5. I assume the Windows version also works but do not have a development environment to test it on.

Also, here's an interesting side note: if you try and replace all occurrences of poll_for_exit in the specs to wait, everything still passes perfectly, and the specs even run a second faster.
