### PR TITLE
Allow IO.pipe to work with Windows by setting INHERIT flag.

### DIFF
--- a/lib/childprocess/windows/functions.rb
+++ b/lib/childprocess/windows/functions.rb
@@ -19,8 +19,21 @@ module ChildProcess
           si[:dwFlags] |= STARTF_USESTDHANDLES
           inherit = true
 
-          si[:hStdOutput] = handle_for(opts[:stdout].fileno) if opts[:stdout]
-          si[:hStdError]  = handle_for(opts[:stderr].fileno) if opts[:stderr]
+          if opts[:stdout]
+            si[:hStdOutput] = handle_for(opts[:stdout].fileno)
+            ok = set_handle_information(si[:hStdOutput].address,
+                                        HANDLE_FLAG_INHERIT,
+                                        HANDLE_FLAG_INHERIT)
+            ok or raise Error, last_error_message
+          end
+
+          if opts[:stderr]
+            si[:hStdError] = handle_for(opts[:stderr].fileno)
+            ok = set_handle_information(si[:hStdError].address,
+                                        HANDLE_FLAG_INHERIT,
+                                        HANDLE_FLAG_INHERIT)
+            ok or raise Error, last_error_message
+          end
         end
 
         if opts[:duplex]


### PR DESCRIPTION
See issue #21.

This fixes this by setting the INHERIT flag on the file handles for the IO objects. Doing this fixed the issue completely.
