### PR TITLE
[BUGFIX] sunos should be considered a synonym for solaris

### DIFF
--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -101,7 +101,7 @@ module ChildProcess
           :windows
         when /cygwin/
           :cygwin
-        when /solaris/
+        when /solaris|sunos/
           :solaris
         when /bsd/
           :bsd


### PR DESCRIPTION
JRuby reports the host os as sunos, rather than solaris. This is inconsistent with cruby, but a fix to JRuby is more complex. This deals with the issue very simply by considering the two to be the same thing (which they are).
