### PR TITLE
Removed Autoload to solve threading issues

### DIFF
--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -4,9 +4,6 @@ require 'childprocess/abstract_io'
 require "fcntl"
 
 module ChildProcess
-  autoload :Unix,     'childprocess/unix'
-  autoload :Windows,  'childprocess/windows'
-  autoload :JRuby,    'childprocess/jruby'
 
   @posix_spawn = false
 
@@ -172,3 +169,7 @@ module ChildProcess
 end # ChildProcess
 
 require 'jruby' if ChildProcess.jruby?
+
+require 'childprocess/unix'    if ChildProcess.unix?
+require 'childprocess/windows' if ChildProcess.windows?
+require 'childprocess/jruby'   if ChildProcess.jruby?


### PR DESCRIPTION
Autoload is not thread-safe. Running child process from within threads
caused errors like `uninitialized constant ChildProcess::Unix::ForkExecProcess`.

The autoload commands are now normal require statements at the bottom of
the file.
