### PR TITLE
Ensuring that all stdout and stderr are pumped to the attached stream

### DIFF
--- a/lib/childprocess/jruby/pump.rb
+++ b/lib/childprocess/jruby/pump.rb
@@ -25,7 +25,7 @@ module ChildProcess
       def pump
         buffer = Java.byte[BUFFER_SIZE].new
 
-        until @stop
+        until @stop && (@input.available == 0)
           read, avail = 0, 0
 
           while read != -1

--- a/spec/io_spec.rb
+++ b/spec/io_spec.rb
@@ -54,6 +54,26 @@ describe ChildProcess do
     end
   end
 
+  it "pumps all output" do
+    10.times do |i|
+      process = echo
+      
+      out = Tempfile.new("duplex")
+      
+      begin
+        process.io.stdout = out
+        
+        process.start
+        process.poll_for_exit(exit_timeout)
+        
+        out.rewind
+        out.read.should == "hello\n"
+      ensure
+        out.close
+      end
+    end
+  end
+
   it "can write to stdin if duplex = true" do
     process = cat
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,6 +107,19 @@ module ChildProcessSpecHelper
     end
   end
 
+  def echo
+    if ChildProcess.os == :windows
+      ruby(<<-CODE)
+            STDIN.sync  = true
+            STDOUT.sync = true
+
+            puts "hello"
+          CODE
+    else
+      ChildProcess.build("echo", "hello")
+    end
+  end
+
   def ruby(code)
     ruby_process(tmp_script(code))
   end


### PR DESCRIPTION
This fixes a bug that is demonstrated with the spec example in jruby.
