### PR TITLE
Bump minimum ffi version

### DIFF
--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", ">= 2.0.0"
   s.add_development_dependency "yard", ">= 0"
   s.add_development_dependency "rake", "~> 0.9.2"
-  s.add_runtime_dependency "ffi", "~> 1.0", ">= 1.0.6"
+  s.add_runtime_dependency "ffi", "~> 1.0", ">= 1.0.11"
 end
 
 


### PR DESCRIPTION
On ruby `ruby 1.9.3p385` I experienced following error when installing ffi gem with `1.0.6` minimum version:

```
StructLayout.c:363:9: error: expression is not assignable
        Data_Get_Struct(rbField, StructField, field = layout->fields[i]);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/Cellar/ruby/1.9.3-p385/include/ruby-1.9.1/ruby/ruby.h:837:12: note: expanded from macro 'Data_Get_Struct'
    (sval) = (type*)DATA_PTR(obj);\
    ~~~~~~ ^
1 error generated.
make: *** [StructLayout.o] Error 1
```

Please allow bumping minimum patch version so it'll compile.
