### PR TITLE
Allow a specific signal to be sent when killing a process.

### DIFF
--- a/spec/childprocess_spec.rb
+++ b/spec/childprocess_spec.rb
@@ -50,8 +50,17 @@ describe ChildProcess do
 
   it "escalates if TERM is ignored" do
     process = ignored('TERM').start
+    sleep(5)
     process.stop
     process.should be_exited
+  end
+
+  it "accepts signals to pass to kill" do
+    process = dies_on_int.start
+    sleep(5)
+    process.stop(3, 'INT')
+    process.should be_exited
+    process.exit_code.should eq 0
   end
 
   it "accepts a timeout argument to #stop" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,16 @@ module ChildProcessSpecHelper
     ruby_process tmp_script(code)
   end
 
+  def dies_on_int
+    code = <<-RUBY
+      trap('TERM', "IGNORE")
+      trap('INT') {exit 0}
+      sleep
+    RUBY
+
+    ruby_process tmp_script(code)
+  end
+
   def write_env(path)
     code = <<-RUBY
       File.open(#{path.inspect}, "w") { |f| f << ENV.inspect }


### PR DESCRIPTION
Some processes (Hi, webrick!) don't honor SIGTERM and return errors on SIGKILL, which can make processes relying on error codes, um... error.

This change allows you to pass a signal to #stop, which it will attempt before trying SIGTERM and SIGKILL.  The parameter is optional, but can be called like `child_process.stop(3, "INT")`.

Also, added a change to the TERM escalation test -- A sleep so it has time to get setup before running.
