### PR TITLE
Ruby 2.4 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ rvm:
   - jruby
   - rbx
   - 2.0.0
-  - 2.1.0
+  - 2.1
+  - 2.2
+  - 2.3.3
+  - 2.4.0
   - ruby-head
 sudo: false
 cache: bundler
@@ -14,5 +17,4 @@ matrix:
   allow_failures:
     - rvm: rbx
     - rvm: ruby-head
-    - rvm: 2.1.0
       env: "CHILDPROCESS_POSIX_SPAWN=true"

--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
 
+  s.add_development_dependency "term-ansicolor", "~> 1.3.2"
   s.add_development_dependency "tins", "~> 1.5.3"
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "yard", ">= 0"

--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
 
+  s.add_development_dependency "tins", "~> 1.5.3"
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "yard", ">= 0"
   s.add_development_dependency "rake", "~> 0.9.2"

--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -116,12 +116,7 @@ module ChildProcess
         host_cpu = RbConfig::CONFIG['host_cpu'].downcase
         case host_cpu
         when /i[3456]86/
-          # Darwin always reports i686, even when running in 64bit mod
-          if os == :macosx && 0xfee1deadbeef.is_a?(Fixnum)
-            "x86_64"
-          else
-            "i386"
-          end
+          "i386"
         when /amd64|x86_64/
           "x86_64"
         when /ppc|powerpc/

--- a/lib/childprocess/abstract_process.rb
+++ b/lib/childprocess/abstract_process.rb
@@ -65,7 +65,7 @@ module ChildProcess
     end
 
     #
-    # @return [Fixnum] the pid of the process after it has started
+    # @return [Integer] the pid of the process after it has started
     #
 
     def pid
@@ -88,7 +88,7 @@ module ChildProcess
     #
     # Forcibly terminate the process, using increasingly harsher methods if possible.
     #
-    # @param [Fixnum] timeout (3) Seconds to wait before trying the next method.
+    # @param [Integer] timeout (3) Seconds to wait before trying the next method.
     #
 
     def stop(timeout = 3)
@@ -98,7 +98,7 @@ module ChildProcess
     #
     # Block until the process has been terminated.
     #
-    # @return [Fixnum] The exit status of the process
+    # @return [Integer] The exit status of the process
     #
 
     def wait

--- a/lib/childprocess/jruby/process.rb
+++ b/lib/childprocess/jruby/process.rb
@@ -50,7 +50,7 @@ module ChildProcess
       # Only supported in JRuby on a Unix operating system, thanks to limitations
       # in Java's classes
       #
-      # @return [Fixnum] the pid of the process after it has started
+      # @return [Integer] the pid of the process after it has started
       # @raise [NotImplementedError] when trying to access pid on non-Unix platform
       #
       def pid

--- a/lib/childprocess/windows/lib.rb
+++ b/lib/childprocess/windows/lib.rb
@@ -307,7 +307,7 @@ module ChildProcess
             else
               handle = get_osfhandle(fd_or_io.fileno)
             end
-          elsif fd_or_io.kind_of?(Fixnum)
+          elsif fd_or_io.kind_of?(Integer)
             handle = get_osfhandle(fd_or_io)
           elsif fd_or_io.respond_to?(:to_io)
             io = fd_or_io.to_io


### PR DESCRIPTION
This gets rid of Fixnum in favor of the unified Integer class. It also expands travis to test more Ruby versions.

I got rid of the odd OS X check, since it actually reports x86_64 locally. I'm not sure if the original workaround was actually for a 32-bit ruby running on a 64-bit system, or for an issue with a specific version of Ruby.