### PR TITLE
Tests of .arch

### DIFF
--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -116,8 +116,8 @@ module ChildProcess
         host_cpu = RbConfig::CONFIG['host_cpu'].downcase
         case host_cpu
         when /i[3456]86/
-          if os == :macosx && RUBY_VERSION < '2.4' && is_64_bit?
-            # Older rubies on Darwin sometimes reported i686 even in 64-bit mode
+          if workaround_older_macosx_misreported_cpu?
+            # Workaround case: older 64-bit Darwin Rubies misreported as i686
             "x86_64"
           else
             "i386"
@@ -168,6 +168,18 @@ module ChildProcess
       end
     end
 
+    # Workaround: detect the situation that an older Darwin Ruby is actually
+    # 64-bit, but is misreporting cpu as i686, which would imply 32-bit.
+    #
+    # @return [Boolean] `true` if:
+    #   (a) on Mac OS X
+    #   (b) on an older Ruby version
+    #   (c) actually running in 64-bit mode
+    def workaround_older_macosx_misreported_cpu?
+      os == :macosx && RUBY_VERSION < '2.4' && is_64_bit?
+    end
+
+    # @return [Boolean] `true` if this Ruby represents `1` in 64 bits (8 bytes).
     def is_64_bit?
       1.size == 8
     end

--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -173,10 +173,9 @@ module ChildProcess
     #
     # @return [Boolean] `true` if:
     #   (a) on Mac OS X
-    #   (b) on an older Ruby version
-    #   (c) actually running in 64-bit mode
+    #   (b) actually running in 64-bit mode
     def workaround_older_macosx_misreported_cpu?
-      os == :macosx && RUBY_VERSION < '2.4' && is_64_bit?
+      os == :macosx && is_64_bit?
     end
 
     # @return [Boolean] `true` if this Ruby represents `1` in 64 bits (8 bytes).

--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -116,14 +116,8 @@ module ChildProcess
         host_cpu = RbConfig::CONFIG['host_cpu'].downcase
         case host_cpu
         when /i[3456]86/
-
-          # Ruby 2.4 unifies Bignum and Fixnum into Integer. Also, I've heard that Darwin no
-          # longer has this issue, so on newer Ruby/Darwin combos this check shouldn't be
-          # needed anyway. Leaving it here for older combinations, however.
-
-          # Check for Ruby older version of Ruby
-          if (RUBY_VERSION < '2.4') && (os == :macosx) && (0xfee1deadbeef.is_a?(Fixnum))
-            # Darwin always reports i686, even when running in 64bit mod
+          if os == :macosx && RUBY_VERSION < '2.4' && is_64_bit?
+            # Older rubies on Darwin sometimes reported i686 even in 64-bit mode
             "x86_64"
           else
             "i386"
@@ -172,6 +166,10 @@ module ChildProcess
         @warnings[msg] = true
         $stderr.puts msg
       end
+    end
+
+    def is_64_bit?
+      1.size == 8
     end
 
   end # class << self

--- a/spec/platform_detection_spec.rb
+++ b/spec/platform_detection_spec.rb
@@ -6,7 +6,7 @@ describe ChildProcess do
   describe ".arch" do
     subject { described_class.arch }
 
-    shared_examples 'expected_arch_for_host_cpu' do |host_cpu:, expected_arch:|
+    shared_examples 'expected_arch_for_host_cpu' do |host_cpu, expected_arch|
       context "when host_cpu is '#{host_cpu}'" do
         before :each do
           allow(RbConfig::CONFIG).
@@ -39,8 +39,8 @@ describe ChildProcess do
         { host_cpu: 'ppc',     expected_arch: 'powerpc' },
         { host_cpu: 'powerpc', expected_arch: 'powerpc' },
         { host_cpu: 'unknown', expected_arch: 'unknown' },
-      ].each do |**args|
-        include_context 'expected_arch_for_host_cpu', **args
+      ].each do |args|
+        include_context 'expected_arch_for_host_cpu', args.values
       end
     end
 
@@ -51,7 +51,7 @@ describe ChildProcess do
       end
 
       context "when host_cpu is 'i686' " do
-        shared_examples 'expected_arch_on_macosx' do |ruby:, is_64:, expected_arch:|
+        shared_examples 'expected_arch_on_macosx' do |ruby, is_64, expected_arch|
           context "when RUBY_VERSION is '#{ruby}'" do
             before :each do
               stub_const("RUBY_VERSION", ruby)
@@ -64,9 +64,7 @@ describe ChildProcess do
                   and_return(is_64)
               end
 
-              include_context 'expected_arch_for_host_cpu',
-                              host_cpu: 'i686',
-                              expected_arch: expected_arch
+              include_context 'expected_arch_for_host_cpu', 'i686', expected_arch
             end
           end
         end
@@ -84,8 +82,8 @@ describe ChildProcess do
           { ruby: '2.4.0', is_64: false, expected_arch: 'i386'   },
           { ruby: '2.5.0', is_64: false, expected_arch: 'i386'   },
           { ruby: '3.0.0', is_64: false, expected_arch: 'i386'   },
-        ].each do |**args|
-          include_context 'expected_arch_on_macosx', **args
+        ].each do |args|
+          include_context 'expected_arch_on_macosx', args.values
         end
       end
 
@@ -95,8 +93,8 @@ describe ChildProcess do
         { host_cpu: 'ppc',     expected_arch: 'powerpc' },
         { host_cpu: 'powerpc', expected_arch: 'powerpc' },
         { host_cpu: 'unknown', expected_arch: 'unknown' },
-      ].each do |**args|
-        include_context 'expected_arch_for_host_cpu', **args
+      ].each do |args|
+        include_context 'expected_arch_for_host_cpu', args.values
       end
     end
   end

--- a/spec/platform_detection_spec.rb
+++ b/spec/platform_detection_spec.rb
@@ -51,39 +51,23 @@ describe ChildProcess do
       end
 
       context "when host_cpu is 'i686' " do
-        shared_examples 'expected_arch_on_macosx' do |ruby, is_64, expected_arch|
-          context "when RUBY_VERSION is '#{ruby}'" do
+        shared_examples 'expected_arch_on_macosx_i686' do |is_64, expected_arch|
+          context "when Ruby is #{is_64 ? 64 : 32}-bit" do
             before :each do
-              stub_const("RUBY_VERSION", ruby)
+              allow(described_class).
+                to receive(:is_64_bit?).
+                and_return(is_64)
             end
 
-            context "when Ruby is #{is_64 ? 64 : 32}-bit" do
-              before :each do
-                allow(described_class).
-                  to receive(:is_64_bit?).
-                  and_return(is_64)
-              end
-
-              include_context 'expected_arch_for_host_cpu', 'i686', expected_arch
-            end
+            include_context 'expected_arch_for_host_cpu', 'i686', expected_arch
           end
         end
 
         [
-          # Prior to Ruby 2.4: check platform word size a different way
-          { ruby: '1.8.7', is_64: true,  expected_arch: 'x86_64' },
-          { ruby: '1.8.7', is_64: false, expected_arch: 'i386'   },
-          { ruby: '1.9.3', is_64: true,  expected_arch: 'x86_64' },
-          { ruby: '1.9.3', is_64: false, expected_arch: 'i386'   },
-          { ruby: '2.3.3', is_64: true,  expected_arch: 'x86_64' },
-          { ruby: '2.3.3', is_64: false, expected_arch: 'i386'   },
-
-          # Ruby 2.4 and later: trust what host_cpu tells us
-          { ruby: '2.4.0', is_64: false, expected_arch: 'i386'   },
-          { ruby: '2.5.0', is_64: false, expected_arch: 'i386'   },
-          { ruby: '3.0.0', is_64: false, expected_arch: 'i386'   },
+          { is_64: true,  expected_arch: 'x86_64' },
+          { is_64: false, expected_arch: 'i386'   }
         ].each do |args|
-          include_context 'expected_arch_on_macosx', args.values
+          include_context 'expected_arch_on_macosx_i686', args.values
         end
       end
 

--- a/spec/platform_detection_spec.rb
+++ b/spec/platform_detection_spec.rb
@@ -1,0 +1,104 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+# Q: Should platform detection concern be extracted from ChildProcess?
+describe ChildProcess do
+
+  describe ".arch" do
+    subject { described_class.arch }
+
+    shared_examples 'expected_arch_for_host_cpu' do |host_cpu:, expected_arch:|
+      context "when host_cpu is '#{host_cpu}'" do
+        before :each do
+          allow(RbConfig::CONFIG).
+            to receive(:[]).
+            with('host_cpu').
+            and_return(expected_arch)
+        end
+
+        after :each do
+          described_class.instance_variable_set(:@arch, nil)
+        end
+
+        it { is_expected.to eq expected_arch }
+      end
+    end
+
+    # Normal cases: not macosx - depends only on host_cpu
+    context "when os is *not* 'macosx'" do
+      before :each do
+        allow(described_class).to receive(:os).and_return(:not_macosx)
+      end
+
+      [
+        { host_cpu: 'i386',    expected_arch: 'i386'    },
+        { host_cpu: 'i486',    expected_arch: 'i386'    },
+        { host_cpu: 'i586',    expected_arch: 'i386'    },
+        { host_cpu: 'i686',    expected_arch: 'i386'    },
+        { host_cpu: 'amd64',   expected_arch: 'x86_64'  },
+        { host_cpu: 'x86_64',  expected_arch: 'x86_64'  },
+        { host_cpu: 'ppc',     expected_arch: 'powerpc' },
+        { host_cpu: 'powerpc', expected_arch: 'powerpc' },
+        { host_cpu: 'unknown', expected_arch: 'unknown' },
+      ].each do |**args|
+        include_context 'expected_arch_for_host_cpu', **args
+      end
+    end
+
+    # Special cases: macosx - when host_cpu is i686, have to re-check
+    context "when os is 'macosx'" do
+      before :each do
+        allow(described_class).to receive(:os).and_return(:macosx)
+      end
+
+      context "when host_cpu is 'i686' " do
+        shared_examples 'expected_arch_on_macosx' do |ruby:, is_64:, expected_arch:|
+          context "when RUBY_VERSION is '#{ruby}'" do
+            before :each do
+              stub_const("RUBY_VERSION", ruby)
+            end
+
+            context "when Ruby is #{is_64 ? 64 : 32}-bit" do
+              before :each do
+                allow(described_class).
+                  to receive(:is_64_bit?).
+                  and_return(is_64)
+              end
+
+              include_context 'expected_arch_for_host_cpu',
+                              host_cpu: 'i686',
+                              expected_arch: expected_arch
+            end
+          end
+        end
+
+        [
+          # Prior to Ruby 2.4: check platform word size a different way
+          { ruby: '1.8.7', is_64: true,  expected_arch: 'x86_64' },
+          { ruby: '1.8.7', is_64: false, expected_arch: 'i386'   },
+          { ruby: '1.9.3', is_64: true,  expected_arch: 'x86_64' },
+          { ruby: '1.9.3', is_64: false, expected_arch: 'i386'   },
+          { ruby: '2.3.3', is_64: true,  expected_arch: 'x86_64' },
+          { ruby: '2.3.3', is_64: false, expected_arch: 'i386'   },
+
+          # Ruby 2.4 and later: trust what host_cpu tells us
+          { ruby: '2.4.0', is_64: false, expected_arch: 'i386'   },
+          { ruby: '2.5.0', is_64: false, expected_arch: 'i386'   },
+          { ruby: '3.0.0', is_64: false, expected_arch: 'i386'   },
+        ].each do |**args|
+          include_context 'expected_arch_on_macosx', **args
+        end
+      end
+
+      [
+        { host_cpu: 'amd64',   expected_arch: 'x86_64'  },
+        { host_cpu: 'x86_64',  expected_arch: 'x86_64'  },
+        { host_cpu: 'ppc',     expected_arch: 'powerpc' },
+        { host_cpu: 'powerpc', expected_arch: 'powerpc' },
+        { host_cpu: 'unknown', expected_arch: 'unknown' },
+      ].each do |**args|
+        include_context 'expected_arch_for_host_cpu', **args
+      end
+    end
+  end
+
+end

--- a/spec/platform_detection_spec.rb
+++ b/spec/platform_detection_spec.rb
@@ -6,6 +6,10 @@ describe ChildProcess do
   describe ".arch" do
     subject { described_class.arch }
 
+    before(:each) { described_class.instance_variable_set(:@arch, nil) }
+
+    after(:each) { described_class.instance_variable_set(:@arch, nil) }
+
     shared_examples 'expected_arch_for_host_cpu' do |host_cpu, expected_arch|
       context "when host_cpu is '#{host_cpu}'" do
         before :each do
@@ -13,10 +17,6 @@ describe ChildProcess do
             to receive(:[]).
             with('host_cpu').
             and_return(expected_arch)
-        end
-
-        after :each do
-          described_class.instance_variable_set(:@arch, nil)
         end
 
         it { is_expected.to eq expected_arch }


### PR DESCRIPTION
This adds full test coverage of the existing the logic of `ChildProcess.arch`. Mocked responses are used to allow continuing to support historical platform oddities without having to reproduce those platform environments.