### PR TITLE
Avoid accessing @logger before definition

### DIFF
--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -31,12 +31,9 @@ module ChildProcess
     alias_method :build, :new
 
     def logger
-      return @logger if @logger
-
-      @logger = Logger.new($stderr)
-      @logger.level = $DEBUG ? Logger::DEBUG : Logger::INFO
-
-      @logger
+      @logger ||= Logger.new($stderr).tap do |logger|
+                    logger.level = $DEBUG ? Logger::DEBUG : Logger::INFO
+                  end
     end
 
     def platform


### PR DESCRIPTION
Fixes the message `warning: instance variable @logger not initialized` that shows up when the tests are run.