### PR TITLE
handle missing interpreter on *NIX

### DIFF
--- a/lib/childprocess/unix/fork_exec_process.rb
+++ b/lib/childprocess/unix/fork_exec_process.rb
@@ -55,7 +55,12 @@ module ChildProcess
 
         # if we don't eventually get EOF, exec() failed
         unless exec_r.eof?
-          raise LaunchError, exec_r.read || "executing command with #{@args.inspect} failed"
+          message = exec_r.read
+          if message.start_with?('No such file or directory') && File.exist?(@args[0])
+            message = nil
+          end
+
+          raise LaunchError, message || "executing command with #{@args.inspect} failed"
         end
 
         ::Process.detach(@pid) if detach?

--- a/spec/unix_spec.rb
+++ b/spec/unix_spec.rb
@@ -37,6 +37,14 @@ if ChildProcess.unix? && !ChildProcess.jruby? && !ChildProcess.posix_spawn?
 
       process.send(:send_signal, 'TERM')
     end
+
+    it "overwrites error message on missing interpreter" do
+      script_path = tmp_script('#!/unlikely/to/exist')
+      File.chmod(0777, script_path)
+      process = ChildProcess.build(script_path)
+
+      expect { process.start }.to raise_error(ChildProcess::LaunchError, /executing command .+? failed/)
+    end
   end
 
   describe ChildProcess::Unix::IO do


### PR DESCRIPTION
Thinking further about #123 I realized that the issue is completely *NIX specific and can be detected easily. So I decided to submit at least a POC for consideration.

The implementation is incomplete in that respect that it only looks the executable up by path (absolute or relative) and ignores the possibility that it could also be somewhere on `PATH`. In case it will be decided to include this workaround in childprocess, I will add this missing part.
