### PR TITLE
Support non-ASCII characters on Windows

### DIFF
--- a/lib/childprocess/windows/lib.rb
+++ b/lib/childprocess/windows/lib.rb
@@ -55,9 +55,9 @@ module ChildProcess
       # );
       #
 
-      attach_function :create_process, :CreateProcessA, [
+      attach_function :create_process, :CreateProcessW, [
         :pointer,
-        :pointer,
+        :buffer_inout,
         :pointer,
         :pointer,
         :bool,

--- a/spec/childprocess_spec.rb
+++ b/spec/childprocess_spec.rb
@@ -107,6 +107,19 @@ describe ChildProcess do
       expect(child_env['CHILD_ONLY']).to eql '1'
     end
   end
+  
+  it 'allows unicode characters in the environment' do
+    Tempfile.open("env-spec") do |file|
+      process = write_env(file.path)
+      process.environment['FOO'] = 'baör'
+      process.start
+      process.wait
+      
+      child_env = eval rewind_and_read(file)
+      
+      expect(child_env['FOO'].force_encoding('UTF-8')).to eql 'baör'
+    end
+  end
 
   it "inherits the parent's env vars also when some are overridden" do
     Tempfile.open("env-spec") do |file|


### PR DESCRIPTION
Use CreateProcessW instead of CreateProcessA to create processes on Windows; allowing for non-ASCII characters in the command line and the environment.