### PR TITLE
Support non-ASCII characters on Windows

### DIFF
--- a/lib/childprocess/windows/lib.rb
+++ b/lib/childprocess/windows/lib.rb
@@ -55,9 +55,9 @@ module ChildProcess
       # );
       #
 
-      attach_function :create_process, :CreateProcessA, [
+      attach_function :create_process, :CreateProcessW, [
         :pointer,
-        :pointer,
+        :buffer_inout,
         :pointer,
         :pointer,
         :bool,

--- a/spec/childprocess_spec.rb
+++ b/spec/childprocess_spec.rb
@@ -109,6 +109,10 @@ describe ChildProcess do
   end
   
   it 'allows unicode characters in the environment' do
+    # This test does not work on Windows for Ruby < 2.3 because ENV values will not be properly decoded
+    # This was fixed in Ruby 2.3 here: https://github.com/ruby/ruby/commit/5e3467c4414df815b3b00d2b0372026b069e7f7d
+    # TODO: Write an alternate test that does not rely on the Ruby ENV hash
+    skip 'Test does not work on Windows for Ruby < 2.3' if Gem.win_platform? && RUBY_VERSION =~ /^1\.|^2\.[0-2]/
     Tempfile.open("env-spec") do |file|
       process = write_env(file.path)
       process.environment['FOO'] = 'baör'

--- a/spec/childprocess_spec.rb
+++ b/spec/childprocess_spec.rb
@@ -107,6 +107,19 @@ describe ChildProcess do
       expect(child_env['CHILD_ONLY']).to eql '1'
     end
   end
+  
+  it 'allows unicode characters in the environment' do
+    Tempfile.open("env-spec") do |file|
+      process = write_env(file.path)
+      process.environment['FOO'] = 'baör'
+      process.start
+      process.wait
+      
+      child_env = eval rewind_and_read(file)
+      
+      expect(child_env['FOO'].force_encoding('UTF-8')).to eql 'baör'
+    end
+  end
 
   it "inherits the parent's env vars also when some are overridden" do
     Tempfile.open("env-spec") do |file|


### PR DESCRIPTION
Use CreateProcessW instead of CreateProcessA to create processes on Windows; allowing for non-ASCII characters in the command line and the environment.

This PR causes one spec test to be skipped for Windows when Ruby < 2.3; and it leaves a `TODO:` comment in the code of that test. For this case, the Ruby ENV hash cannot be used to check the child environment because it will not be reliably encoded/decoded by Ruby. 
The TODO item is to re-write the test in a way that does not require ruby's ENV hash.