### PR TITLE
Only require FFI on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,13 @@ if RUBY_VERSION =~ /^1\./
   gem 'term-ansicolor', '< 1.4' # The 'term-ansicolor' gem requires Ruby 2.x on/after this version
 
   if RbConfig::CONFIG['host_os'].downcase =~ /mswin|msys|mingw32/
-    gem 'ffi', '< 1.9.15' # The 'ffi' gem, for Windows, requires Ruby 2.x on/after this version
+    # The 'ffi' gem, for Windows, requires Ruby 2.x on/after this version
+    gem 'ffi', '< 1.9.15'
+  else
+    # Load 'ffi' for testing posix_spawn
+    gem 'ffi' if ENV['CHILDPROCESS_POSIX_SPAWN'] == 'true'
   end
+else
+  # Load 'ffi' for testing posix_spawn, or on windows.
+  gem 'ffi' if ENV['CHILDPROCESS_POSIX_SPAWN'] == 'true' || RbConfig::CONFIG['host_os'].downcase =~ /mswin|msys|mingw32/
 end

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ ChildProcess.posix_spawn = true
 process = ChildProcess.build(*args)
 ```
 
+To be able to use this, please make sure that you have the `ffi` gem installed.
+
 ### Ensure entire process tree dies
 
 By default, the child process does not create a new process group. This means there's no guarantee that the entire process tree will die when the child process is killed. To solve this:

--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "ffi", "~> 1.0", ">= 1.0.11"
-
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "yard", "~> 0.0"
   s.add_development_dependency 'rake', '< 12.0'
   s.add_development_dependency 'coveralls', '< 1.0'
+
+  s.extensions = 'ext/mkrf_conf.rb'
 end
 
 

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,24 @@
+# Based on the example from https://en.wikibooks.org/wiki/Ruby_Programming/RubyGems#How_to_install_different_versions_of_gems_depending_on_which_version_of_ruby_the_installee_is_using
+require 'rubygems'
+require 'rubygems/command.rb'
+require 'rubygems/dependency_installer.rb'
+
+begin
+  Gem::Command.build_args = ARGV
+rescue NoMethodError # rubocop:disable Lint/HandleExceptions
+end
+
+inst = Gem::DependencyInstaller.new
+
+begin
+  if RbConfig::CONFIG['host_os'] =~ %r{mswin|msys|mingw32}i
+    inst.install 'ffi',  "~> 1.0", ">= 1.0.11"
+  end
+rescue # rubocop:disable Lint/RescueWithoutErrorClass
+  exit(1)
+end
+
+ # create dummy rakefile to indicate success
+File.open(File.join(File.dirname(__FILE__), 'Rakefile'), 'w') do |f|
+  f.write("task :default\n")
+end

--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -73,7 +73,12 @@ module ChildProcess
       enabled = @posix_spawn || %w[1 true].include?(ENV['CHILDPROCESS_POSIX_SPAWN'])
       return false unless enabled
 
-      require 'ffi'
+      begin
+        require 'ffi'
+      rescue LoadError
+        raise ChildProcess::MissingFFIError
+      end
+
       begin
         require "childprocess/unix/platform/#{ChildProcess.platform_name}"
       rescue LoadError

--- a/lib/childprocess/errors.rb
+++ b/lib/childprocess/errors.rb
@@ -14,6 +14,17 @@ module ChildProcess
   class LaunchError < Error
   end
 
+  class MissingFFIError < Error
+    def initialize
+      message = "FFI is a required pre-requisite for posix_spawn, falling back to default implementation. " +
+                "Please add it to your deployment to unlock this functionality. " +
+                "If you believe this is an error, please file a bug at http://github.com/enkessler/childprocess/issues"
+
+      super(message)
+    end
+
+  end
+
   class MissingPlatformError < Error
     def initialize
       message = "posix_spawn is not yet supported on #{ChildProcess.platform_name} (#{RUBY_PLATFORM}), falling back to default implementation. " +


### PR DESCRIPTION
This allows users to trade off between full-featured and
always-deployable by removing the hard dependency on a native extension.
The user of the gem needs to depend on FFI themselves to enable
`posix_spawn` on Linux.