### PR TITLE
Add support for DragonFly BSD

### DIFF
--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -113,7 +113,7 @@ module ChildProcess
           :cygwin
         when /solaris|sunos/
           :solaris
-        when /bsd/
+        when /bsd|dragonfly/
           :bsd
         when /aix/
           :aix


### PR DESCRIPTION
DragonFly BSD is a fork of FreeBSD, it should work with the defaults of the rest of BSDs