### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ rvm:
   - 2.5
   - ruby-head
 
-sudo: true # Necessary to fix JRuby
+sudo: false
 
 cache: bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ cache: bundler
 
 before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
-  - gem update --system
-  - gem install bundler  # Necessary to fix 1.9.3
+  # RubyGems update is supported for Ruby 2.3 and later
+  - if $(ruby -e "puts Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')"); then gem update --system; fi
+  - gem install bundler --version '~> 1.17'
 
 env:
   global:


### PR DESCRIPTION
Recent deprecations in RubyGems and version constraints in Bundler 2.0.0 require us to be more explicit in our build steps in order for builds to pass. Skip builds on certain versions and specify an explicit constraint when installing Bundler.

We also switched back to `sudo: false` since there didn't actually seem to be a need for it, and this will speed up builds.

I'll investigate AppVeyor build failures separately.