### PR TITLE
Support JRuby on Java >= 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ before_install:
   - ruby -e "system('gem update --system') if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')"
   - gem install bundler --version '~> 1.17'
 
+before_script:
+  - 'export JAVA_OPTS="${JAVA_OPTS_FOR_SPECS}"'
+
 env:
   global:
   matrix:
@@ -36,6 +39,10 @@ matrix:
     - rvm: jruby-9.1.9.0
     - rvm: ruby-head
     - env: "CHILDPROCESS_POSIX_SPAWN=true"
+  include:
+  - rvm: jruby-9.2.5.0
+    jdk: openjdk11
+    env: "JAVA_OPTS_FOR_SPECS='--add-opens java.base/java.io=org.jruby.dist --add-opens java.base/sun.nio.ch=org.jruby.dist'"
   exclude:
     # Travis does not provide 1.9.3 on OSX
   - rvm: 1.9.3

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ ChildProcess.logger = logger
 ## Caveats
 
 * With JRuby on Unix, modifying `ENV["PATH"]` before using childprocess could lead to 'Command not found' errors, since JRuby is unable to modify the environment used for PATH searches in `java.lang.ProcessBuilder`. This can be avoided by setting `ChildProcess.posix_spawn = true`.
+* With JRuby on Java >= 9, the JVM may need to be configured to allow JRuby to access neccessary implementations; this can be done by adding `--add-opens java.base/java.io=org.jruby.dist` and `--add-opens java.base/sun.nio.ch=org.jruby.dist` to the `JAVA_OPTS` environment variable that is used by JRuby when launching the JVM.
+
 
 # Implementation
 


### PR DESCRIPTION
The JRuby implementation against Javas <= 8 relied on reflection into a
package-private class `java.lang.UNIXProcess` to get the pid of a process
running on UNIX/posix systems, but that class was removed in Java 9 which
also adds `java.lang.Process#pid()`.

At load, determine the effective major version of Java, and then define
an implementation that uses modern Java's `java.lang.Process#pid()` where
available, falling back to the original implementation on legacy Javas.

***

The `JAVA_OPTS` environment variable is used by JRuby to launch the JVM with
appropriate options; by adding specific `--add-opens` flags, we are able to
enable the specific reflective access that is necessary to run in Javas >= 9.
