### PR TITLE
Cut 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### master (unreleased)
+### Version 1.0.0 / 2019-01-28
 
 * [#134](https://github.com/enkessler/childprocess/pull/134): Add support for non-ASCII characters on Windows
 * [#132](https://github.com/enkessler/childprocess/pull/132): Install `ffi` gem requirement on Windows only

--- a/lib/childprocess/version.rb
+++ b/lib/childprocess/version.rb
@@ -1,3 +1,3 @@
 module ChildProcess
-  VERSION = '0.9.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
@enkessler If it's useful, here's a PR for cutting a release. I changed the format of the change log to use the present tense imperative style—if this is not appropriate feel free to change! (it tends to result in fewer words/characters)

* [#134](https://github.com/enkessler/childprocess/pull/134): Add support for non-ASCII characters on Windows
* [#132](https://github.com/enkessler/childprocess/pull/132): Install `ffi` gem requirement on Windows only
* [#128](https://github.com/enkessler/childprocess/issues/128): Convert environment variable values to strings when `posix_spawn` enabled
* [#141](https://github.com/enkessler/childprocess/pull/141): Support JRuby on Java >= 9