### PR TITLE
Relax rake gem constraint from <=11.x to <=12.x.

### DIFF
--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard", "~> 0.0"
   s.add_development_dependency 'coveralls', '< 1.0'
 
-  s.add_runtime_dependency 'rake', '< 12.0'
+  s.add_runtime_dependency 'rake', '< 13.0'
 
   # Install FFI gem if we're running on Windows
   s.extensions = 'ext/mkrf_conf.rb'


### PR DESCRIPTION
Rake 12 has been released for quite some time. Given this gem doesn't depend on `rake` per se (it is only required to avoid installing the `ffi` gem on non-Windows environments), relax the constraint.

To prevent accidental breakage due to a new Rake release, we'll still pin to < 13 for now.