### PR TITLE
Drop support for Ruby 2.0, 2.1, and 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ os:
 rvm:
   - jruby-9.1.9.0
   - rbx-3
-  - 2.0.0
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
@@ -42,10 +39,3 @@ matrix:
   - rvm: jruby-9.2.5.0
     jdk: openjdk11
     env: "JAVA_OPTS_FOR_SPECS='--add-opens java.base/java.io=org.jruby.dist --add-opens java.base/sun.nio.ch=org.jruby.dist'"
-  exclude:
-    # Travis does not provide 1.9.3 on OSX
-  - rvm: 1.9.3
-    os: osx
-    # Travis does not provide 2.0.0 on it latest version of OSX
-  - rvm: 2.0.0
-    os: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### dev / unreleased
+
+* Drop support for Ruby 2.0, 2.1, and 2.2
+
 ### Version 1.0.1 / 2019-02-03
 
 * [#143](https://github.com/enkessler/childprocess/pull/144): Fix installs by adding `rake` gem as runtime dependency

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ a standalone library.
 [![Code Climate](https://codeclimate.com/github/enkessler/childprocess.svg)](https://codeclimate.com/github/enkessler/childprocess)
 [![Coverage Status](https://coveralls.io/repos/enkessler/childprocess/badge.svg?branch=master)](https://coveralls.io/r/enkessler/childprocess?branch=master)
 
-***
-**This project currently needs a new maintainer. If anyone is interested, please contact me, [enkessler](https://github.com/enkessler).**
-***
+# Requirements
+
+* Ruby 2.3+, JRuby 9+
 
 # Usage
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,24 +4,6 @@ environment:
   matrix:
     - CHILDPROCESS_POSIX_SPAWN: true
       CHILDPROCESS_UNSET: should-be-unset
-      RUBY_VERSION: 200-x64
-    - CHILDPROCESS_POSIX_SPAWN: false
-      CHILDPROCESS_UNSET: should-be-unset
-      RUBY_VERSION: 200-x64
-    - CHILDPROCESS_POSIX_SPAWN: true
-      CHILDPROCESS_UNSET: should-be-unset
-      RUBY_VERSION: 21-x64
-    - CHILDPROCESS_POSIX_SPAWN: false
-      CHILDPROCESS_UNSET: should-be-unset
-      RUBY_VERSION: 21-x64
-    - CHILDPROCESS_POSIX_SPAWN: true
-      CHILDPROCESS_UNSET: should-be-unset
-      RUBY_VERSION: 22-x64
-    - CHILDPROCESS_POSIX_SPAWN: false
-      CHILDPROCESS_UNSET: should-be-unset
-      RUBY_VERSION: 22-x64
-    - CHILDPROCESS_POSIX_SPAWN: true
-      CHILDPROCESS_UNSET: should-be-unset
       RUBY_VERSION: 23-x64
     - CHILDPROCESS_POSIX_SPAWN: false
       CHILDPROCESS_UNSET: should-be-unset

--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 2.3.0'
+
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "yard", "~> 0.0"
   s.add_development_dependency 'coveralls', '< 1.0'


### PR DESCRIPTION
These Ruby versions are no longer supported. Including these in our CI builds slows the feedback cycle and introduces a maintenance burden for which there is no clear user base.

These Rubies have not been supported for quite some time:
1. Ruby 2.0 since Februrary 24th, 2016
2. Ruby 2.1 since April 1st, 2017
3. Ruby 2.2 since June 20th, 2018

[1] https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/
[2] https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/
[3] https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/

Opening this for any comments. Is there a good reason to maintain support for these versions?

Once merged, this would likely prompt a bump to version 2.0.0, given the introduction of the Ruby version constraint to the gemspec.