### PR TITLE
Rewrite unix fork reopen to be compatible with ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
 
 sudo: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,12 @@ environment:
     - CHILDPROCESS_POSIX_SPAWN: false
       CHILDPROCESS_UNSET: should-be-unset
       RUBY_VERSION: 25-x64
+    - CHILDPROCESS_POSIX_SPAWN: true
+      CHILDPROCESS_UNSET: should-be-unset
+      RUBY_VERSION: 26-x64
+    - CHILDPROCESS_POSIX_SPAWN: false
+      CHILDPROCESS_UNSET: should-be-unset
+      RUBY_VERSION: 26-x64
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%

--- a/lib/childprocess/unix/fork_exec_process.rb
+++ b/lib/childprocess/unix/fork_exec_process.rb
@@ -29,8 +29,16 @@ module ChildProcess
           exec_r.close
           set_env
 
-          STDOUT.reopen(stdout || "/dev/null")
-          STDERR.reopen(stderr || "/dev/null")
+          if stdout
+            STDOUT.reopen(stdout)
+          else
+            STDOUT.reopen("/dev/null", "a+")
+          end
+          if stderr
+            STDERR.reopen(stderr)
+          else
+            STDERR.reopen("/dev/null", "a+")
+          end
 
           if duplex?
             STDIN.reopen(reader)


### PR DESCRIPTION
On ruby 2.6 the original code would fail specs:

lib/childprocess/unix/fork_exec_process.rb:32:in `reopen': exclusive
access mode is not supported (ArgumentError)

The documentation for reopen shows that it has two ways to call it:

  reopen(other_IO) -> ios
  reopen(path, mode [,opt]) -> ios

With ruby 2.4 and 2.5 calling reopen with a path and no mode seems to
work fine, but with ruby 2.6 this triggers the spec failure.

This commit splits the calls based on stdout/stderr availability so
that both types of reopen calls can get the required parameters. This
fixes the 2.6 specs while being backward compatible with ruby 2.4 and
2.5.