### PR TITLE
Fix ChildProcess::Unix::Process#wait method with leader processes

### DIFF
--- a/lib/childprocess/unix/process.rb
+++ b/lib/childprocess/unix/process.rb
@@ -50,7 +50,8 @@ module ChildProcess
         if exited?
           exit_code
         else
-          _, status = ::Process.waitpid2 _pid
+          _, status = ::Process.waitpid2(@pid)
+
           set_exit_code(status)
         end
       end


### PR DESCRIPTION
Issue #151 reported a problem where in the update from Ruby 2.5 to Ruby 2.6 some programs would block forever on a `Process.waitpid2` call.

Changing the call to pass in a positive PID instead of the negative PID fixes the issue as it will call the `waitpid` system call right away instead of delaying it for later.

See #151 for further discussion of the possible reasons for the behavior.