### PR TITLE
 Fix ChildProcess::Unix::Process#exited? method with leader processes

### DIFF
--- a/lib/childprocess/unix/process.rb
+++ b/lib/childprocess/unix/process.rb
@@ -29,7 +29,7 @@ module ChildProcess
         return true if @exit_code
 
         assert_started
-        pid, status = ::Process.waitpid2(_pid, ::Process::WNOHANG | ::Process::WUNTRACED)
+        pid, status = ::Process.waitpid2(@pid, ::Process::WNOHANG | ::Process::WUNTRACED)
         pid = nil if pid == 0 # may happen on jruby
 
         log(:pid => pid, :status => status)


### PR DESCRIPTION
Sorry, I found another edge case following on from my leader-process problems in #151 

```ruby
require "childprocess"

ChildProcess.logger.level = 0

# Start a background thread that launches a long-lived process.
# The child process will be killed once this script finishes (via at_exit)
Thread.new do
  child1 = ChildProcess.build("yes")
  child1.start
  at_exit do
    child1.stop
  end
  status = child1.wait
end

# give the bg thread some time to ensure child1.wait has happened
sleep 0.1

# Start a second child process
child2 = ChildProcess.build("sleep", "100")
child2.leader = true
child2.start
puts "child2.stop"
child2.stop
puts "Child2 is done!"
```

When child2.stop is called, we send it TERM, then poll for it to exit with `::Process.waitpid2(_pid, ::Process::WNOHANG | ::Process::WUNTRACED)`.  The process dies straight away, but under ruby 2.6, that waitpid2 call always returns `nil`, until we hit the stop-timeout, at which point we sent the child a KILL.

In OS X, that KILL raises `Errno::EPERM`.  In Linux, it seems like it just swallows the signal being sent to a dead process.

WDYT to this fix?  I'm not really familiar with unix leader process, so would welcome additional scrutiny.