### PR TITLE
gemspec: Drop rubyforge_project property

### DIFF
--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{A simple and reliable solution for controlling external programs running in the background on any Ruby / OS combination.}
   s.description = %q{This gem aims at being a simple and reliable solution for controlling external programs running in the background on any Ruby / OS combination.}
 
-  s.rubyforge_project = "childprocess"
   s.license           = 'MIT'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
This has been removed without a replacement.