### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ cache: bundler
 
 before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
-  - gem update --system
-  - gem install bundler --version '~> 1.17'
+  - gem install bundler
 
 before_script:
   - 'export JAVA_OPTS="${JAVA_OPTS_FOR_SPECS}"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
 
 rvm:
   - rbx-3
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
@@ -16,8 +15,7 @@ cache: bundler
 
 before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
-  # RubyGems update is supported for Ruby 2.3 and later
-  - ruby -e "system('gem update --system') if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')"
+  - gem update --system
   - gem install bundler --version '~> 1.17'
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### master (unreleased)
+
+* [#167](https://github.com/enkessler/childprocess/pull/167): Fix detach behavior on Windows
+
 ### Version 3.0.0 / 2019-09-20
 
 * [#156](https://github.com/enkessler/childprocess/pull/156): Remove unused `rubyforge_project` from gemspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### master (unreleased)
+### Version 4.0.0 / 2020-06-18
 
 * [#167](https://github.com/enkessler/childprocess/pull/167): Fix detach behavior on Windows
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ a standalone library.
 
 # Requirements
 
-* Ruby 2.3+, JRuby 9+
+* Ruby 2.4+, JRuby 9+
 
 Windows users **must** ensure the `ffi` gem (`>= 1.0.11`) is installed in order to use ChildProcess.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,6 @@ environment:
   matrix:
     - CHILDPROCESS_POSIX_SPAWN: true
       CHILDPROCESS_UNSET: should-be-unset
-      RUBY_VERSION: 23-x64
-    - CHILDPROCESS_POSIX_SPAWN: false
-      CHILDPROCESS_UNSET: should-be-unset
-      RUBY_VERSION: 23-x64
-    - CHILDPROCESS_POSIX_SPAWN: true
-      CHILDPROCESS_UNSET: should-be-unset
       RUBY_VERSION: 24-x64
     - CHILDPROCESS_POSIX_SPAWN: false
       CHILDPROCESS_UNSET: should-be-unset

--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "yard", "~> 0.0"

--- a/lib/childprocess/version.rb
+++ b/lib/childprocess/version.rb
@@ -1,3 +1,3 @@
 module ChildProcess
-  VERSION = '3.0.0'
+  VERSION = '4.0.0'
 end


### PR DESCRIPTION
The build doesn't work and this version has been EOL for years. We will consider also dropping support for 2.4 once the build stops passing on that version.