### PR TITLE
Use PosixSpawnProcess instead of ForkExecProcess on platforms without fork

### DIFF
--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -15,10 +15,10 @@ module ChildProcess
     def new(*args)
       case os
       when :macosx, :linux, :solaris, :bsd, :cygwin, :aix
-        if posix_spawn?
-          Unix::PosixSpawnProcess.new(args)
-        elsif jruby?
+        if jruby? && !posix_spawn_chosen_explicitly?
           JRuby::Process.new(args)
+        elsif posix_spawn?
+          Unix::PosixSpawnProcess.new(args)
         else
           Unix::ForkExecProcess.new(args)
         end
@@ -69,8 +69,12 @@ module ChildProcess
       os == :windows
     end
 
+    def posix_spawn_chosen_explicitly?
+      @posix_spawn || %w[1 true].include?(ENV['CHILDPROCESS_POSIX_SPAWN'])
+    end
+
     def posix_spawn?
-      enabled = @posix_spawn || %w[1 true].include?(ENV['CHILDPROCESS_POSIX_SPAWN'])
+      enabled = posix_spawn_chosen_explicitly? || !Process.respond_to?(:fork)
       return false unless enabled
 
       begin


### PR DESCRIPTION
* Such as on TruffleRuby, JRuby, etc.
* ForkExecProcess does not work at all on these platforms anyway.
* PosixSpawnProcess is not thread-safe with regard to the current working directory (https://github.com/oracle/truffleruby/issues/1525#issuecomment-445780033) but it's still better than failing with no fork.
* https://github.com/enkessler/childprocess/issues/172 is the proper solution longer-term.

With this the test suite passes on TruffleRuby, except for 4 tests.

I don't feel great about the lack of thread-safety with https://github.com/enkessler/childprocess/blob/c005912c7e13422bc036ec59eaa9dc1570d78d4d/lib/childprocess/unix/posix_spawn_process.rb#L43 but it seems better than just failing.

I would much prefer https://github.com/enkessler/childprocess/pull/175, but this may be easier to integrate shorter-term, and doesn't need a new major version bump.