### PR TITLE
Fix argument delegation (Ruby 3x)

### DIFF
--- a/lib/childprocess.rb
+++ b/lib/childprocess.rb
@@ -16,14 +16,14 @@ module ChildProcess
       case os
       when :macosx, :linux, :solaris, :bsd, :cygwin, :aix
         if posix_spawn?
-          Unix::PosixSpawnProcess.new(args)
+          Unix::PosixSpawnProcess.new(*args)
         elsif jruby?
-          JRuby::Process.new(args)
+          JRuby::Process.new(*args)
         else
-          Unix::ForkExecProcess.new(args)
+          Unix::ForkExecProcess.new(*args)
         end
       when :windows
-        Windows::Process.new(args)
+        Windows::Process.new(*args)
       else
         raise Error, "unsupported platform #{platform_name.inspect}"
       end

--- a/lib/childprocess/abstract_process.rb
+++ b/lib/childprocess/abstract_process.rb
@@ -39,7 +39,7 @@ module ChildProcess
     # @see ChildProcess.build
     #
 
-    def initialize(args)
+    def initialize(*args)
       unless args.all? { |e| e.kind_of?(String) }
         raise ArgumentError, "all arguments must be String: #{args.inspect}"
       end

--- a/lib/childprocess/windows.rb
+++ b/lib/childprocess/windows.rb
@@ -12,19 +12,11 @@ module ChildProcess
       extend FFI::Library
 
       def self.msvcrt_name
-        host_part = RbConfig::CONFIG['host_os'].split("_")[1]
-        manifest  = File.join(RbConfig::CONFIG['bindir'], 'ruby.exe.manifest')
-
-        if host_part && host_part.to_i > 80 && File.exists?(manifest)
-          "msvcr#{host_part}"
-        else
-          "msvcrt"
-        end
+        RbConfig::CONFIG['RUBY_SO_NAME'][/msvc\w+/] || 'ucrtbase'
       end
 
       ffi_lib "kernel32", msvcrt_name
       ffi_convention :stdcall
-
 
     end # Library
   end # Windows


### PR DESCRIPTION
Prior to this change, using childprocess in a Ruby 3 environment would generate `wrong number of arguments` errors.

This change attempts to address the errors by ensuring that we are properly delegating arguments in childprocess and the abstract_process classes.

Tests appear to pass locally on Ruby 3.2.0.

Happy to take direction/feedback.