### PR TITLE
Replace `File.exists?` with `File.exist?`

### DIFF
--- a/lib/childprocess/windows.rb
+++ b/lib/childprocess/windows.rb
@@ -15,7 +15,7 @@ module ChildProcess
         host_part = RbConfig::CONFIG['host_os'].split("_")[1]
         manifest  = File.join(RbConfig::CONFIG['bindir'], 'ruby.exe.manifest')
 
-        if host_part && host_part.to_i > 80 && File.exists?(manifest)
+        if host_part && host_part.to_i > 80 && File.exist?(manifest)
           "msvcr#{host_part}"
         else
           "msvcrt"


### PR DESCRIPTION
`File.exists?` has been deprecated since Ruby 2.1, and will be removed since Ruby 3.2.