### PR TITLE
Remove ostruct dependency from specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,10 +11,10 @@ require 'rspec'
 require 'tempfile'
 require 'socket'
 require 'stringio'
-require 'ostruct'
 
 module ChildProcessSpecHelper
   RUBY = defined?(Gem) ? Gem.ruby : 'ruby'
+  CapturedOutput = Struct.new(:stdout, :stderr)
 
   def ruby_process(*args)
     @process = ChildProcess.build(RUBY , *args)
@@ -229,7 +229,7 @@ module ChildProcessSpecHelper
 
     yield
 
-    OpenStruct.new stdout: rewind_and_read(out), stderr: rewind_and_read(err)
+    CapturedOutput.new rewind_and_read(out), rewind_and_read(err)
   ensure
     STDOUT.reopen orig_out
     STDERR.reopen orig_err


### PR DESCRIPTION
Starting in Ruby 3.4, the following deprecation warning is printed when running the childprocess specs:

> childprocess/spec/spec_helper.rb:14: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.

This commit fixes this warning by removing the dependency on the `ostruct` gem entirely, replacing it with a normal `Struct`.