### PR TITLE
Add logger dependency to fix warning on Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', jruby, truffleruby ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', head, jruby, truffleruby ]
         # CRuby < 2.6 does not support macos-arm64, so test those on amd64 instead
         # JRuby 9.4.7.0 does not have native console support on macos-arm64: https://github.com/jruby/jruby/issues/8271
         include:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in child_process.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gemspec
 
 # Used for local development/testing only
 gem 'rake'
+
+# Newer versions of term-ansicolor (used by coveralls) do not work on Ruby 2.4
+gem 'term-ansicolor', '< 1.8.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')

--- a/childprocess.gemspec
+++ b/childprocess.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4.0'
 
+  s.add_dependency "logger", "~> 1.5"
+
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "yard", "~> 0.0"
   s.add_development_dependency 'coveralls', '< 1.0'


### PR DESCRIPTION
When using `childprocess` on Ruby 3.4.0.dev, the following warning is printed:

> lib/childprocess.rb:7: warning: logger was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add logger to your Gemfile or gemspec.

This PR fixes the warning by adding the `logger` gem as a gemspec dependency.

I chose `~> 1.5` as the requirement because 1.5.0 is the most recent version that supports Ruby 2.4.

I also added Ruby head to the CI matrix.